### PR TITLE
Address plugin submission feedback

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -19,7 +19,11 @@ export default class LavadocsPlugin extends Plugin {
 		const content = await this.getActiveFileContent();
 		const slug = await this.sluggifiedFileName();
 
-		const ribbonIconEl = this.addRibbonIcon('mountain', 'Push to Lavadocs', (evt: MouseEvent) => {		
+		const ribbonIconEl = this.addRibbonIcon('mountain', 'Push to Lavadocs', (evt: MouseEvent) => {
+			if (!title || !content || !slug) {
+				new Notice("No active file");
+				return;
+			}
 			this.pushToLavadocs(title, content, slug);
 		});
 		ribbonIconEl.addClass('lavadocs-ribbon-class');
@@ -52,7 +56,7 @@ export default class LavadocsPlugin extends Plugin {
 		await this.saveData(this.settings);
 	}
 
-	async pushToLavadocs(title: string | null, content: string | null, slug: string | null) {
+	async pushToLavadocs(title: string, content: string, slug: string) {
 		const requestParams: RequestUrlParam = {
 			method: "POST",
 			headers: {
@@ -96,8 +100,7 @@ export default class LavadocsPlugin extends Plugin {
 			const name = activeFile.basename;
 			return name;
 		} 
-			
-		new Notice("No active file");
+		
 		return null;
 	}
 
@@ -120,7 +123,7 @@ export default class LavadocsPlugin extends Plugin {
 			return titleSluggified;
 		}
 
-		return null
+		return null;
 	}
 }
 

--- a/main.ts
+++ b/main.ts
@@ -104,7 +104,7 @@ export default class LavadocsPlugin extends Plugin {
 	async getActiveFileContent() {
 		const activeFile = this.app.workspace.getActiveFile();
 		if (activeFile) {
-			const fileData = await this.app.vault.read(activeFile);
+			const fileData = await this.app.vault.cachedRead(activeFile);
 			return fileData;
 		}
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,10 @@
 {
 	"id": "lavadocs",
 	"name": "Lavadocs",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"minAppVersion": "0.15.0",
-	"description": "Public docs, from the fires of your Obsidian vault.",
+	"description": "Public docs, from the fires of your vault.",
 	"author": "Saalik Lokhandwala",
 	"authorUrl": "https://saaliklok.com",
-	"fundingUrl": "https://lavadocs.com",
 	"isDesktopOnly": false
 }


### PR DESCRIPTION
Submitted this plugin to the Obsidian team to review. This PR addresses that feedback and bumps a patch version.

- [x] Use the Obsidian API's `requestUrl` rather than 
- [x] Use `checkCallback` to ensure a file is active before attempting to push to Lavadocs
- [x] Use `cachedRead` instead of simply `read` on the current file's data
- [x] Manifest changes
- [x] Round of QA