### PR TITLE
Launch Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ After installing the plugin, you'll need to connect your Lavadocs account:
 With the Lavadocs plugin enabled, sharing your documents is straightforward:
 
 1. Open the document you wish to share in Obsidian.
-2. Click on the newly added ⛰️ mountain icon in your sidebar, or run “Push to Lavadocs” from your command palette.
-3. Your document will be pushed to Lavadocs, and you should be able to access and share it.
+2. Click on the newly added ⛰️ mountain icon in your sidebar.
+3. Your document will be pushed to Lavadocs, and you should be able to access and share it!
 
 ## Lavadocs Pricing
 

--- a/main.ts
+++ b/main.ts
@@ -20,7 +20,6 @@ export default class LavadocsPlugin extends Plugin {
 			const { title, content, slug } = await this.getActiveFileDetails();
 			
 			if (!title || !content || !slug) {
-				new Notice("No active file");
 				return;
 			}
 			this.pushToLavadocs(title, content, slug);
@@ -80,25 +79,22 @@ export default class LavadocsPlugin extends Plugin {
 	async getActiveFileDetails() {
 		const activeFile = this.app.workspace.getActiveFile();
 
-		const title = activeFile?.basename;
-		const content = await this.getActiveFileContent(activeFile);
-		const slug = activeFile?.basename.toLowerCase().replace(/[^a-zA-Z0-9\s]/g, "");
-		
-		if (!title || !content || !slug) {
-			new Notice("No active file");
-			return { title: null, content: null, slug: null };
-		}
-
-		return { title, content, slug };
-	}
-
-	async getActiveFileContent(activeFile: TFile | null) {
 		if (activeFile) {
-			const fileData = await this.app.vault.cachedRead(activeFile);
-			return fileData;
-		}
+			const title = activeFile.basename;
+			const content = await this.app.vault.cachedRead(activeFile);
+			const slug = activeFile.basename.toLowerCase().replace(/[^a-zA-Z0-9\s]/g, "");
+			
 
-		return null;
+			if (!title || !content || !slug) {
+				new Notice("Can't push an empty file");
+				return { title: null, content: null, slug: null };
+			}
+
+			return { title, content, slug };
+		} 
+			
+		new Notice("No active file");
+		return { title: null, content: null, slug: null };
 	}
 }
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Notice, Plugin, PluginSettingTab, RequestUrlParam, Setting, TFile, requestUrl } from 'obsidian';
+import { App, Notice, Plugin, PluginSettingTab, RequestUrlParam, Setting, requestUrl } from 'obsidian';
 
 interface LavadocsPluginSettings {
 	lavaKey: string;
@@ -38,7 +38,7 @@ export default class LavadocsPlugin extends Plugin {
 	}
 
 	async pushToLavadocs(title: string, content: string, slug: string) {
-		const requestParams: RequestUrlParam = {
+		const lavadocsRequestParams: RequestUrlParam = {
 			url: "https://lavadocs.com/api/v1/documents",
 			method: "POST",
 			headers: {
@@ -54,11 +54,10 @@ export default class LavadocsPlugin extends Plugin {
 			})
 		};
 
-		const response = requestUrl(requestParams);
+		const lavadocsResponse = requestUrl(lavadocsRequestParams);
 
 		try {
-			const data = await response.json;
-			
+			const data = await lavadocsResponse.json;
 			new Notice("Pushed to Lavadocs!");
 
 			if (this.settings.openNewWindow) {

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,5 @@
 import { App, Notice, Plugin, PluginSettingTab, RequestUrlParam, Setting, TFile, requestUrl } from 'obsidian';
 
-const prodUrl = "https://lavadocs.com";
-const devUrl = "http://localhost:3000";
-
 interface LavadocsPluginSettings {
 	lavaKey: string;
 	openNewWindow: boolean;
@@ -30,26 +27,6 @@ export default class LavadocsPlugin extends Plugin {
 		});
 		ribbonIconEl.addClass('lavadocs-ribbon-class');
 
-		this.addCommand({
-			id: 'push-to-lavadocs',
-			name: 'Push',
-			checkCallback: (checking: boolean) => {
-				(async () => {
-					const { title, content, slug } = await this.getActiveFileDetails();
-
-					if (title && content && slug) {
-	
-						if (!checking) {
-							this.pushToLavadocs(title, content, slug);
-						}
-	
-						return true;
-					}
-					return false;
-				})();
-			},
-		});
-
 		this.addSettingTab(new LavadocsSettings(this.app, this));
 	}
 
@@ -63,7 +40,7 @@ export default class LavadocsPlugin extends Plugin {
 
 	async pushToLavadocs(title: string, content: string, slug: string) {
 		const requestParams: RequestUrlParam = {
-			url: `${devUrl}/api/v1/documents`,
+			url: "https://lavadocs.com/api/v1/documents",
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -86,7 +63,7 @@ export default class LavadocsPlugin extends Plugin {
 			new Notice("Pushed to Lavadocs!");
 
 			if (this.settings.openNewWindow) {
-				window.open(`${devUrl}/users/${data.username}/documents/${data.slug}`)
+				window.open(`https://lavadocs.com/users/${data.username}/documents/${data.slug}`)
 			}
 		} catch (error) {
 			if (error.status === 401) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "lavadocs",
 	"name": "Lavadocs",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"minAppVersion": "0.15.0",
 	"description": "Public docs, from the fires of your vault.",
 	"author": "Saalik Lokhandwala",


### PR DESCRIPTION
This PR makes a critical bug fix, removes an unneeded feature, and features a few refactors

- During revisions for plugin submission, the code for getting the active file's contents was moved around. It was pushed into the `onload()` function, which meant that the file data was only fetched on first load of the Vault, not when the button to push to Lavadocs was clicked. This bug is fixed here, along with DRY'ing up of some code, and a couple refactors.
- The revision also made it such that errors were not notifying users properly. More robust error handling has been added here to ensure that's not the case.
- Finally, after testing, it was clear that the button in the sidebar is the preferred way to push to Lavadocs. Pushing to Lavadocs from the command palette has been removed for now.