### PR TITLE
Configure settings for self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ After installing the plugin, you'll need to connect your Lavadocs account:
 1. In your browser, log into Lavadocs and copy your `Lava Key`. (It's in your [Account Settings](https://lavadocs.com/users/edit))
 2. In Obsidian, head to Settings > Community Plugins > Lavadocs.
 3. Paste in your “Lava Key” to authenticate your account.
-4. If you're self-hosting Lavadocs, include the domain it's hosted on.
+4. If you're self-hosting Lavadocs, include the full URL it's hosted on.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ After installing the plugin, you'll need to connect your Lavadocs account:
 1. In your browser, log into Lavadocs and copy your `Lava Key`. (It's in your [Account Settings](https://lavadocs.com/users/edit))
 2. In Obsidian, head to Settings > Community Plugins > Lavadocs.
 3. Paste in your “Lava Key” to authenticate your account.
+4. If you're self-hosting Lavadocs, include the domain it's hosted on.
 
 ## Usage
 
@@ -44,8 +45,14 @@ With the Lavadocs plugin enabled, sharing your documents is straightforward:
 
 There's more on the [landing page](https://lavadocs.com/home), but the TLDR is: Your docs are yours to keep.
 
+Hosted edition:
+
 - **Start With**: 50 documents free.
 - **Additional Documents**: For every 100 additional documents, it's $4.99.
+
+Self-hosted edition:
+
+- Get access to the self-hosted edition code repository, with gift pricing: pay what you want.
 
 ## Privacy
 

--- a/main.ts
+++ b/main.ts
@@ -2,13 +2,13 @@ import { App, Notice, Plugin, PluginSettingTab, RequestUrlParam, Setting, reques
 
 interface LavadocsPluginSettings {
 	lavaKey: string;
-	domain: string;
+	url: string;
 	openNewWindow: boolean;
 }
 
 const DEFAULT_SETTINGS: LavadocsPluginSettings = {
 	lavaKey: '',
-	domain: "lavadocs.com",
+	url: "https://lavadocs.com",
 	openNewWindow: true
 }
 
@@ -41,7 +41,7 @@ export default class LavadocsPlugin extends Plugin {
 
 	async pushToLavadocs(title: string, content: string, slug: string) {
 		const lavadocsRequestParams: RequestUrlParam = {
-			url: `https://${this.settings.domain}/api/v1/documents`,
+			url: `${this.settings.url}/api/v1/documents`,
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -63,7 +63,7 @@ export default class LavadocsPlugin extends Plugin {
 			new Notice("Pushed to Lavadocs!");
 
 			if (this.settings.openNewWindow) {
-				window.open(`https://${this.settings.domain}/users/${data.username}/documents/${data.slug}`)
+				window.open(`${this.settings.url}/users/${data.username}/documents/${data.slug}`)
 			}
 		} catch (error) {
 			if (error.status === 401) {
@@ -134,10 +134,10 @@ class LavadocsSettings extends PluginSettingTab {
 				}));
 		
 		new Setting(containerEl)
-		.setName("Hosted Domain")
-		.setDesc("If you're hosting your own Lavadocs instance, enter the domain here.")
+		.setName("Hosted URL")
+		.setDesc("If you're hosting your own Lavadocs instance, enter the full url here.")
 		.addText(text => text
-			.setPlaceholder('lavadocs.com')
+			.setPlaceholder('https://lavadocs.com')
 			.setValue(this.plugin.settings.domain)
 			.onChange(async (value) => {
 				this.plugin.settings.domain = value;

--- a/main.ts
+++ b/main.ts
@@ -2,11 +2,13 @@ import { App, Notice, Plugin, PluginSettingTab, RequestUrlParam, Setting, reques
 
 interface LavadocsPluginSettings {
 	lavaKey: string;
+	domain: string;
 	openNewWindow: boolean;
 }
 
 const DEFAULT_SETTINGS: LavadocsPluginSettings = {
 	lavaKey: '',
+	domain: "lavadocs.com",
 	openNewWindow: true
 }
 
@@ -39,7 +41,7 @@ export default class LavadocsPlugin extends Plugin {
 
 	async pushToLavadocs(title: string, content: string, slug: string) {
 		const lavadocsRequestParams: RequestUrlParam = {
-			url: "https://lavadocs.com/api/v1/documents",
+			url: `https://${this.settings.domain}/api/v1/documents`,
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
@@ -61,7 +63,7 @@ export default class LavadocsPlugin extends Plugin {
 			new Notice("Pushed to Lavadocs!");
 
 			if (this.settings.openNewWindow) {
-				window.open(`https://lavadocs.com/users/${data.username}/documents/${data.slug}`)
+				window.open(`https://${this.settings.domain}/users/${data.username}/documents/${data.slug}`)
 			}
 		} catch (error) {
 			if (error.status === 401) {
@@ -130,5 +132,16 @@ class LavadocsSettings extends PluginSettingTab {
 					this.plugin.settings.openNewWindow = value;
 					await this.plugin.saveSettings();
 				}));
+		
+		new Setting(containerEl)
+		.setName("Hosted Domain")
+		.setDesc("If you're hosting your own Lavadocs instance, enter the domain here.")
+		.addText(text => text
+			.setPlaceholder('lavadocs.com')
+			.setValue(this.plugin.settings.domain)
+			.onChange(async (value) => {
+				this.plugin.settings.domain = value;
+				await this.plugin.saveSettings();
+			}));
 	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "lavadocs",
 	"name": "Lavadocs",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"minAppVersion": "0.15.0",
 	"description": "Public docs, from the fires of your vault.",
 	"author": "Saalik Lokhandwala",


### PR DESCRIPTION
This PR amends the Obsidian plugin to substitute the URL from the default hosted `lavadocs.com` to whatever is defined in settings. 

This allows those who are self-hosting Obsidian to enter their hosted URL -- which will push their documents to their own server.